### PR TITLE
スマホ版のheader, footer

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -7,8 +7,6 @@ body {
 /* header */
 
 header {
-    /* window 基準 */
-    position: absolute;
     width: 100%;
     height: 80px;
     left: 0px;
@@ -34,7 +32,7 @@ header {
     top: 20.5px;
 }
 
-.header_right {
+#pc_header_right {
     display: flex;
     justify-content: flex-end;
     /* 右寄せ */
@@ -104,7 +102,6 @@ header {
     order: 0;
 }
 
-
 /* footer */
 
 footer {
@@ -156,12 +153,6 @@ footer {
     padding: 0px;
     gap: 24px;
 
-    /* position: absolute; */
-    width: 103px;
-    height: 66px;
-    left: 769.22px;
-    top: 68px;
-
     color: var(--base-color-white);
 
     flex: none;
@@ -193,8 +184,6 @@ footer {
     /* position: absolute; */
     width: 176px;
     height: 44px;
-    left: 968.22px;
-    top: 60px;
 
     background: var(--base-color-white);
     border-radius: 1000px;
@@ -214,4 +203,72 @@ footer {
     padding-bottom: 27px;
     text-align: center;
     color: var(--base-color-white);
+}
+
+
+/* responsive */
+@media screen and (max-width: 900px) {
+    header {
+        height: 44px;
+    }
+
+    #header_logo {
+        position: absolute;
+        width: 186.13px;
+        height: 24px;
+        left: 22px;
+        top: 10px;
+    }
+
+    #pc_header_right {
+        display: none;
+    }
+
+    #phone_header_right {
+        display: flex;
+        justify-content: flex-end;
+        /* 右寄せ */
+        flex-direction: row;
+        align-items: center;
+        margin: 0px;
+        padding: 10px;
+    }
+
+    .footer_menu {
+        padding: 24px;
+        gap: 20px;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: flex-start;
+    }
+
+    #footer_logo {
+        width: 80vw;
+    }
+
+    .footer_about {
+        gap: 8px;
+    }
+
+    .footer_toc {
+        /* Auto layout */
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 0px;
+        gap: 8px;
+
+        color: var(--base-color-white);
+
+        flex: none;
+        order: 2;
+        flex-grow: 1;
+    }
+}
+
+@media screen and (min-width: 900px) {
+    #phone_header {
+        display: none;
+    }
 }

--- a/css/toppage.css
+++ b/css/toppage.css
@@ -151,7 +151,7 @@
     align-items: center;
     justify-content: space-around;
     flex-wrap: wrap;
-    gap: 64px;
+    gap: 32px;
     padding: 0px 16px;
 }
 
@@ -274,6 +274,8 @@
     align-items: center;
     justify-content: space-around;
 
+    flex-wrap: wrap;
+
     /* height: 160px; */
     width: 100%;
     padding: 37px 60px;
@@ -345,24 +347,20 @@
 /* - faq */
 .main_faq {
     display: flex;
-    flex-direction: row;
-    align-items: center;
-    padding: 0px;
-    /* gap: 100px; */
-    width: 100%;
-    justify-content: space-between;
-}
-
-.main_faq_text {
-    display: flex;
     flex-direction: column;
     align-items: flex-start;
     padding: 0px;
     gap: 8px;
+    width: 100%;
+}
 
-    flex-grow: 1;
-    width: 80px;
-    height: 24px;
+.main_faq_text {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0px;
+    width: 100%;
 }
 
 .main_faq_button {
@@ -380,4 +378,110 @@
 .main_faq_button_text {
     /* subcopy */
     color: var(--base-color-white);
+}
+
+
+
+/* responsive */
+@media screen and (max-width: 900px) {
+    .top {
+        flex-direction: column;
+        align-items: center;
+        padding: 24px 24px 0px;
+        gap: 30px;
+    }
+
+    #top_right_fig {
+        width: 100vw;
+    }
+
+    .top_left {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 24px;
+        padding-left: 0px;
+    }
+
+    .top_left_copy {
+        width: min(300px, 95vw);
+    }
+    .main {
+        gap: 40px;
+        padding: 24px;
+    }
+
+    .main_part {
+        gap: 24px;
+    }
+
+    .main_service_card_description {
+        width: 100px;
+        /* 最小値 */
+        flex-grow: 1;
+    }
+
+
+    .main_cando_section {
+        gap: 16px;
+    }
+
+    .main_cando_subsection {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0px;
+    }
+
+    .main_invite {
+        padding: 24px;
+        gap: 20px;
+        background: var(--brand-color-gradation);
+        border-radius: 16px;
+    }
+
+    .main_environment_subsection {
+        gap: 16px;
+    }
+
+    .main_environment_subsubsections {
+        flex-direction: column;
+        padding: 0px;
+        gap: 16px;
+    }
+
+    .main_environment_subsubsection {
+        gap: 8px;
+    }
+
+    .main_faq {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .main_faq_text {
+        width: 100%;
+    }
+
+    .main_faq_button {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+        padding: 10px 24px;
+        gap: 10px;
+
+        background: var(--brand-color-secondary);
+        border-radius: 1000px;
+    }
+
+    .main_faq_button_text {
+        /* subcopy */
+        color: var(--base-color-white);
+    }
+}
+
+@media screen and (min-width: 900px) {
+    #phone_header_right {
+        display: none;
+    }
 }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <a href="index.html"><img id="header_logo" src="figure/Logo primary.svg" type="image/svg+xml"
                 alt="Titech App Project"></a>
 
-        <div class="header_right">
+        <div id="pc_header_right">
             <div class="header_right_toc">
                 <div class="header_right_toc_top caption">
                     <a href="index.html">新歓サイトTOP</a>
@@ -34,7 +34,13 @@
                 </div>
             </a>
         </div>
+
+        <div id="phone_header_right">
+            TOC
+        </div>
     </header>
+
+    <!-- common part end -->
 
     <div class="top">
         <div class="top_left">
@@ -259,17 +265,19 @@
                 <div class="main_sectionname pop-up_title">
                     FAQ
                 </div>
-                <div class="main_sectiontext caption">
-                    多く寄せられる質問事項とその回答をまとめています
-                </div>
+                <a class="main_faq_button" href="faq.html">
+                    <div class="main_faq_button_text subcopy">
+                        詳しくみる
+                    </div>
+                </a>
             </div>
-            <a class="main_faq_button" href="faq.html">
-                <div class="main_faq_button_text subcopy">
-                    詳しくみる
-                </div>
-            </a>
+            <div class="main_faq_caption caption">
+                多く寄せられる質問事項とその回答をまとめています
+            </div>
         </div>
     </div>
+
+    <!-- common part start -->
 
     <footer>
         <div class="footer_menu">


### PR DESCRIPTION
- メディアクエリを使ってスマホ版表示を実装。閾値は900px
  - ヘッダー右はpc版・スマホ版2つ作成 (無駄DOMへの配慮でヘッダー全体にはしない)
  - 本文のpaddingやgapも画面幅900px未満のとき減るように
- 未実装部分
  - スマホ版ヘッダー右の目次
  - FAQページ